### PR TITLE
#130: change toolbar in plan element details view to not collapsing

### DIFF
--- a/App/app/src/main/java/com/github/travelplannerapp/planelementdetails/PlanElementDetailsActivity.kt
+++ b/App/app/src/main/java/com/github/travelplannerapp/planelementdetails/PlanElementDetailsActivity.kt
@@ -12,7 +12,6 @@ import com.google.android.material.snackbar.Snackbar
 import dagger.android.AndroidInjection
 import kotlinx.android.synthetic.main.activity_plan_element_details.*
 import kotlinx.android.synthetic.main.activity_search_element.*
-import kotlinx.android.synthetic.main.activity_travel_details.collapsing
 import kotlinx.android.synthetic.main.item_place_element_info.*
 import kotlinx.android.synthetic.main.toolbar.*
 import javax.inject.Inject
@@ -61,7 +60,7 @@ class PlanElementDetailsActivity : AppCompatActivity(), PlanElementDetailsContra
     }
 
     override fun showTitle(title: String) {
-        collapsing.title = title
+        supportActionBar?.title = title
     }
 
     override fun showInfoLayout(isVisible: Boolean) {

--- a/App/app/src/main/res/layout/activity_plan_element_details.xml
+++ b/App/app/src/main/res/layout/activity_plan_element_details.xml
@@ -11,31 +11,22 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar"
         android:layout_width="match_parent"
-        android:layout_height="300dp"
+        android:layout_height="wrap_content"
         android:fitsSystemWindows="true"
         android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
 
-        <com.google.android.material.appbar.CollapsingToolbarLayout
-            android:id="@+id/collapsing"
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/materialPlanElementDetails"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:fitsSystemWindows="true"
             app:contentScrim="?attr/colorPrimary"
             app:expandedTitleMarginEnd="64dp"
-            app:expandedTitleMarginStart="48dp"
-            app:layout_scrollFlags="scroll|exitUntilCollapsed">
-
-            <ImageView
-                android:id="@+id/imageTravelDetails"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:fitsSystemWindows="true"
-                android:scaleType="centerCrop"
-                app:layout_collapseMode="parallax" />
+            app:expandedTitleMarginStart="48dp">
 
             <include layout="@layout/toolbar" />
 
-        </com.google.android.material.appbar.CollapsingToolbarLayout>
+        </com.google.android.material.appbar.MaterialToolbar>
 
     </com.google.android.material.appbar.AppBarLayout>
 


### PR DESCRIPTION
as showing a photo is very low priority, I'm changing travel details to have small title, not a big and scrollable one:

![Uploading Screenshot_1572094988.png…]()